### PR TITLE
Custom transition fix

### DIFF
--- a/addons/ScenesManager/Helpers/GodotHelpers.cs
+++ b/addons/ScenesManager/Helpers/GodotHelpers.cs
@@ -155,6 +155,19 @@ namespace MoF.Addons.ScenesManager.Helpers
 
             return mainContainer;
         }
+        
+        /// <summary>
+        /// Gets the project viewport size from project settings.
+        /// </summary>
+        /// <returns></returns>
+        public static Vector2 GetProjectViewportSize()
+        {
+            return new Vector2()
+            {
+                X = ProjectSettings.GetSetting("display/window/size/viewport_width", 1152).As<int>(),
+                Y = ProjectSettings.GetSetting("display/window/size/viewport_height", 648).As<int>(),
+            };
+        }
     }
 }
 #endif

--- a/addons/ScenesManager/TransitionNode.cs
+++ b/addons/ScenesManager/TransitionNode.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Godot;
 using MoF.Addons.ScenesManager.Scripts;
 using MoF.Addons.ScenesManager.Constants;
+using MoF.Addons.ScenesManager.Helpers;
 
 namespace MoF.Addons.ScenesManager
 {
@@ -387,6 +388,7 @@ namespace MoF.Addons.ScenesManager
 			}
 
 			_targetSceneRoot = GetNode<Control>(AddonConstants.TransitionNode.TargetSceneContainer);
+			_targetSceneRoot.SetSize(GodotHelpers.GetProjectViewportSize());
 
 			if (_targetPackedScene == null)
 			{
@@ -434,6 +436,7 @@ namespace MoF.Addons.ScenesManager
 			}
 
 			_currentSceneRoot = GetNode<Control>(AddonConstants.TransitionNode.CurrentSceneContainer);
+			_currentSceneRoot.SetSize(GodotHelpers.GetProjectViewportSize());
 
 			if (_currentSceneNode == null)
 			{


### PR DESCRIPTION
Fix when creating a custom transition scene, the current scene and target scene are hidden by default.

